### PR TITLE
Update Program.cs

### DIFF
--- a/PRMasterServer/Program.cs
+++ b/PRMasterServer/Program.cs
@@ -159,7 +159,11 @@ namespace PRMasterServer
                 Log("Executing command: " + command);
                 if (command == "/nndclear" && serverNatNeg != null)
                 {
-                    serverNatNeg.clientsClear();
+                    ServerNatNeg._clientsClear(true);
+                }
+                else if (command == "/nndshow" && serverNatNeg != null)
+                {
+                    ServerNatNeg._clientsClear(false);
                 }
                 else if (command == "/list" && serverListRetrieve != null)
                 { 


### PR DESCRIPTION
/nndshow shows contents of _clients
/nndclear shows contents of _clients and then clears the contents
When someone will get bugged connections with natneg again, info in _clients can potentially give some insights as to why that happens. And we should test if clearing _clients will make people be able to connect, after they get bugged natneg without natneg restart
